### PR TITLE
Fix link in report

### DIFF
--- a/update_all.ps1
+++ b/update_all.ps1
@@ -46,6 +46,7 @@ $Options = [ordered]@{
             NoIcons     = $false                            #  Markdown: don't show icon
             IconSize    = 32                                #  Markdown: icon size
             Title       = ''                                #  Markdown, Text: TItle of the report, by default 'Update-AUPackages'
+            PackageSourceBranch = 'main'                    #  Markdown: package source branch  
         }
     }
 


### PR DESCRIPTION
Fixes link in [update report](https://gist.github.com/swissgrc-bot/bcac0ec9e5582d0c4c76777c9effcddb) to point to correct branch