### PR TITLE
Fix creation of GitHub releases

### DIFF
--- a/update_all.ps1
+++ b/update_all.ps1
@@ -69,6 +69,7 @@ $Options = [ordered]@{
     GitReleases  = @{
         ApiToken    = $Env:github_api_key                   #Your github api key
         ReleaseType = 'package'                             #Either 1 release per date, or 1 release per package
+        Branch      = 'main'                                #Branch to create release on
     }
 
     RunInfo = @{


### PR DESCRIPTION
Create releases on `main` branch.

Fixes this error: https://github.com/swissgrc/chocolatey-packages/runs/7851635538?check_suite_focus=true#step:6:48