### PR TITLE
Fix missing permissions to push changes to repository

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -26,13 +26,6 @@ jobs:
         with:
           fetch-depth: 0 # History plugin requires complete log
           token: ${{ secrets.GITHUBREPO_API_KEY }} # Use a token from swissgrc-bot user, since it has permission to bypass branch protection policy
-      # Defines Git settings used for updating packages
-      - name: Initialize Git environment
-        shell: powershell
-        run: |
-          git config --global user.email "bot@swissgrc.com"
-          git config --global user.name "Swiss GRC"
-          git config --global core.safecrlf false
       # Show information about available environment
       - name: Show environment information
         shell: powershell

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # renovate: tag=v3.0.2
         with:
           fetch-depth: 0 # History plugin requires complete log
+          token: ${{ secrets.GITHUBREPO_API_KEY }} # Use a token from swissgrc-bot user, since it has permission to bypass branch protection policy
       # Defines Git settings used for updating packages
       - name: Initialize Git environment
         shell: powershell


### PR DESCRIPTION
Use a user specific access token (from `swissgrc-bot`) to checkout Git repository so that build can bypass branch policies (which contain an exclusion for `swissgrc-bot`).

Fixes this error: https://github.com/swissgrc/chocolatey-packages/pull/14