### PR TITLE
Fix SonarLint update script

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,11 @@ jobs:
         run: |
           git clone -q https://github.com/majkinetor/au.git $Env:TEMP/au
           . "$Env:TEMP/au/scripts/Install-AU.ps1" $Env:AU_VERSION
+      # Install required modules
+      - name: Install required modules
+        shell: powershell
+        run: |
+          Install-Module PowerShellForGitHub -Force
       # Test packages
       - name: Test packages
         continue-on-error: true

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -52,6 +52,11 @@ jobs:
         run: |
           git clone -q https://github.com/majkinetor/au.git $Env:TEMP/au
           . "$Env:TEMP/au/scripts/Install-AU.ps1" $Env:AU_VERSION
+      # Install required modules
+      - name: Install required modules
+        shell: powershell
+        run: |
+          Install-Module PowerShellForGitHub -Force
       # Update packages
       - name: Run update
         continue-on-error: true


### PR DESCRIPTION
Fixes update of SonarLint package by using GitHub API instead of scraping website.

Fixes #30 