### PR TITLE
Fix dotnet-uninstall asset URL

### DIFF
--- a/automatic/dotnet-uninstaller/update.ps1
+++ b/automatic/dotnet-uninstaller/update.ps1
@@ -1,4 +1,5 @@
 import-module au
+import-module PowerShellForGitHub
 
 $repoOwner = 'dotnet'
 $repoName = 'cli-lab'


### PR DESCRIPTION
The .msi release asset name changed and no longer contains the version name, so the regex pattern no longer matches.

The [current GitHub release](https://github.com/dotnet/cli-lab/releases/tag/1.7.618124) of dotnet-uninstaller is 1.7.618124.

The [current Chocolatey version](https://community.chocolatey.org/packages/dotnet-uninstaller) is 1.7.550802.
